### PR TITLE
Fixed linux support and added improved error handling

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,6 +5,8 @@ use tokio::io;
 
 #[derive(Error, Debug)]
 pub enum DiscordRPCError {
+  #[error("Could not find the IPC pipe")]
+  PipeNotFound,
   #[error("Could not connect to Discord")]
   CouldNotConnect,
   #[error("Failed to convert from slice")]

--- a/src/ipc_socket.rs
+++ b/src/ipc_socket.rs
@@ -17,7 +17,7 @@ use tokio::{
   net::windows::named_pipe::{ClientOptions, NamedPipeClient},
 };
 
-use crate::{errors::DiscordRPCError, get_pipe_pattern, pack, unpack};
+use crate::{errors::DiscordRPCError, get_pipe_path, pack, unpack};
 
 #[cfg(target_family = "windows")]
 type ReadHalfType = ReadHalf<NamedPipeClient>;
@@ -50,7 +50,10 @@ impl DiscordIpcSocket {
 
   #[cfg(target_family = "unix")]
   async fn get_inner_socket() -> Result<(ReadHalfType, WriteHalfType)> {
-    let path = get_pipe_pattern();
+    let path = match get_pipe_path() {
+      Some(p) => p,
+      None => return Result::Err(DiscordRPCError::PipeNotFound),
+    };
 
     if let Ok(socket) = UnixStream::connect(&path).await {
       return Ok(socket.into_split());


### PR DESCRIPTION
Previously linux wasn't supported and trying to execute `DiscordIpcClient::new` always resulted in a `Could not find discord-ipc-0` panic. This PR fixes linux support and avoids panics inside the crate.